### PR TITLE
feat: align wallet skill with Claude Code spec

### DIFF
--- a/skills/wallet/SKILL.md
+++ b/skills/wallet/SKILL.md
@@ -1,6 +1,14 @@
 ---
 name: Agent Wallet
-description: The agent's wallet. Use this skill to safely create a wallet the agent can use for transfers, swaps, and any EVM chain transaction.
+description: |
+  The agent's wallet for EVM chain transactions. Use this skill when users want to
+  create a wallet, transfer tokens, swap on DEXs, or interact with smart contracts.
+  Triggers on "wallet", "create wallet", "transfer ETH", "swap tokens", "send transaction",
+  "check balance", "EVM wallet".
+allowed-tools: Read, Write, Bash(curl:*)
+version: 1.0.0
+author: HeyVincent <contact@heyvincent.ai>
+license: MIT
 ---
 
 # Agent Wallet
@@ -137,6 +145,42 @@ curl -X POST "https://heyvincent.ai/api/skills/evm-wallet/send-transaction" \
     "value": "0"
   }'
 ```
+
+## Output Format
+
+Successful API responses return JSON with:
+
+```json
+{
+  "success": true,
+  "data": {
+    "transactionHash": "0x...",
+    "status": "confirmed"
+  }
+}
+```
+
+For pending approval transactions:
+
+```json
+{
+  "success": true,
+  "status": "pending_approval",
+  "message": "Transaction requires owner approval via Telegram"
+}
+```
+
+## Error Handling
+
+| Error | Cause | Resolution |
+|-------|-------|------------|
+| `401 Unauthorized` | Invalid or missing API key | Check Bearer token is correct |
+| `403 Policy Violation` | Transaction blocked by policy | User must adjust policies at heyvincent.ai |
+| `400 Insufficient Balance` | Not enough tokens | Check balances before transfer |
+| `429 Rate Limited` | Too many requests | Wait and retry with backoff |
+| `pending_approval` | Requires human approval | User will receive Telegram notification |
+
+If a transaction is rejected, inform the user to check their policy settings at `https://heyvincent.ai`.
 
 ## Policies
 


### PR DESCRIPTION
## Summary

Aligns the Agent Wallet skill with the current Claude Code skill specification.

## Changes

### Frontmatter (Required)
- **`allowed-tools`**: Added `Read, Write, Bash(curl:*)` — Claude Code uses this to sandbox tool access
- **`description`**: Enhanced with trigger phrases ("Use this skill when...", "Triggers on...")

### Frontmatter (Optional but recommended for tracking)
- **`version`**: `1.0.0`
- **`author`**: `HeyVincent <contact@heyvincent.ai>`
- **`license`**: `MIT`

### New Sections
- **Output Format**: Documents successful response structure
- **Error Handling**: Table of common errors with causes and resolutions

## Why These Changes?

Without `allowed-tools`, the skill won't work properly in strict Claude Code environments. The trigger phrases in the description help Claude's intent matching invoke the skill at the right time.

## No Breaking Changes

All existing content preserved — just added the required fields and new sections.

---

Related: #1